### PR TITLE
feat: use dynamic import for solc

### DIFF
--- a/example.js
+++ b/example.js
@@ -2,23 +2,28 @@ const { generateSolidityCode, generateEVMByteCode } = require('./')
 const fs = require('fs')
 const path = require('path')
 
-generate('checkpoint')
-generate('limboExit')
-generate('order')
-generate('ownership')
-generate('su')
+compileAllExamples().then(console.log)
 
-function generate(name) {
+async function compileAllExamples() {
+  await generate('checkpoint')
+  await generate('limboExit')
+  await generate('order')
+  await generate('ownership')
+  await generate('su')
+  return 'all examples compiled'
+}
+
+async function generate(name) {
   console.log(`compiling ${name}`)
   const source = fs.readFileSync(
     path.join(__dirname, `./examples/${name}/${name}.txt`)
   )
-  const output = generateSolidityCode(source.toString())
+  const output = await generateSolidityCode(source.toString())
   fs.writeFileSync(
     path.join(__dirname, `./examples/${name}/${getContractName(name)}.sol`),
     output
   )
-  const evmOutput = generateEVMByteCode(source.toString())
+  const evmOutput = await generateEVMByteCode(source.toString())
   fs.writeFileSync(
     path.join(__dirname, `./examples/${name}/${getContractName(name)}.json`),
     evmOutput

--- a/src/generator/CodeGenerator.ts
+++ b/src/generator/CodeGenerator.ts
@@ -1,5 +1,5 @@
 import { CompiledPredicate } from '../transpiler'
 
 export interface CodeGenerator {
-  generate(claimDefs: CompiledPredicate[]): string
+  generate(claimDefs: CompiledPredicate[]): Promise<string>
 }

--- a/src/generator/solidity/SolidityCodeGenerator.test.ts
+++ b/src/generator/solidity/SolidityCodeGenerator.test.ts
@@ -21,7 +21,7 @@ describe('SolidityCodeGenerator', () => {
   beforeEach(async () => {})
 
   describe('operator', () => {
-    test('and', () => {
+    test('and', async () => {
       const input: CompiledPredicate[] = [
         {
           type: 'CompiledPredicate',
@@ -52,11 +52,11 @@ describe('SolidityCodeGenerator', () => {
           entryPoint: 'AndTestA'
         }
       ]
-      const output = generator.generate(input)
+      const output = await generator.generate(input)
       const testOutput = readFile('operators/TestAnd.sol', output)
       expect(output).toBe(testOutput.toString())
     })
-    test('or', () => {
+    test('or', async () => {
       const input: CompiledPredicate[] = [
         {
           type: 'CompiledPredicate',
@@ -87,11 +87,11 @@ describe('SolidityCodeGenerator', () => {
           entryPoint: 'OrTestO'
         }
       ]
-      const output = generator.generate(input)
+      const output = await generator.generate(input)
       const testOutput = readFile('operators/TestOr.sol', output)
       expect(output).toBe(testOutput.toString())
     })
-    test('not', () => {
+    test('not', async () => {
       const input: CompiledPredicate[] = [
         {
           type: 'CompiledPredicate',
@@ -117,11 +117,11 @@ describe('SolidityCodeGenerator', () => {
           entryPoint: 'NotTestN'
         }
       ]
-      const output = generator.generate(input)
+      const output = await generator.generate(input)
       const testOutput = readFile('operators/TestNot.sol', output)
       expect(output).toBe(testOutput.toString())
     })
-    test('forall', () => {
+    test('forall', async () => {
       const input: CompiledPredicate[] = [
         {
           type: 'CompiledPredicate',
@@ -159,11 +159,11 @@ describe('SolidityCodeGenerator', () => {
           entryPoint: 'ForallTestF'
         }
       ]
-      const output = generator.generate(input)
+      const output = await generator.generate(input)
       const testOutput = readFile('operators/TestForall.sol', output)
       expect(output).toBe(testOutput.toString())
     })
-    test('there', () => {
+    test('there', async () => {
       const input: CompiledPredicate[] = [
         {
           type: 'CompiledPredicate',
@@ -197,14 +197,14 @@ describe('SolidityCodeGenerator', () => {
           entryPoint: 'ThereTestT'
         }
       ]
-      const output = generator.generate(input)
+      const output = await generator.generate(input)
       const testOutput = readFile('operators/TestThere.sol', output)
       expect(output).toBe(testOutput.toString())
     })
   })
 
   describe('bind', () => {
-    test('bindand', () => {
+    test('bindand', async () => {
       const input: IntermediateCompiledPredicate = {
         type: 'IntermediateCompiledPredicate',
         originalPredicateName: 'BindAndTest',
@@ -243,7 +243,7 @@ describe('SolidityCodeGenerator', () => {
       expect(outputOfDecide).toBe(testOutputOfDecide.toString())
     })
 
-    test('bind2', () => {
+    test('bind2', async () => {
       const input: IntermediateCompiledPredicate = {
         type: 'IntermediateCompiledPredicate',
         originalPredicateName: 'Bind2Test',
@@ -269,7 +269,7 @@ describe('SolidityCodeGenerator', () => {
       expect(output).toBe(testOutput.toString())
     })
 
-    test('bindval', () => {
+    test('bindval', async () => {
       const input: IntermediateCompiledPredicate = {
         type: 'IntermediateCompiledPredicate',
         originalPredicateName: 'BindValTest',
@@ -303,7 +303,7 @@ describe('SolidityCodeGenerator', () => {
       expect(output).toBe(testOutput.toString())
     })
 
-    test('bindaddr', () => {
+    test('bindaddr', async () => {
       const input: IntermediateCompiledPredicate = {
         type: 'IntermediateCompiledPredicate',
         originalPredicateName: 'BindAddrTest',
@@ -338,7 +338,7 @@ describe('SolidityCodeGenerator', () => {
   })
 
   describe('variable', () => {
-    test('eval1', () => {
+    test('eval1', async () => {
       const input: IntermediateCompiledPredicate = {
         type: 'IntermediateCompiledPredicate',
         originalPredicateName: 'EvalTest',
@@ -383,7 +383,7 @@ describe('SolidityCodeGenerator', () => {
       expect(outputOfGetChild).toBe(testOutputOfGetChild.toString())
       expect(outputOfDecide).toBe(testOutputOfDecide.toString())
     })
-    test('forval', () => {
+    test('forval', async () => {
       const input: IntermediateCompiledPredicate = {
         type: 'IntermediateCompiledPredicate',
         originalPredicateName: 'ForValTest',
@@ -414,7 +414,7 @@ describe('SolidityCodeGenerator', () => {
       )
       expect(outputOfGetChild).toBe(testOutputOfGetChild.toString())
     })
-    test('thereval', () => {
+    test('thereval', async () => {
       const input: IntermediateCompiledPredicate = {
         type: 'IntermediateCompiledPredicate',
         originalPredicateName: 'ThereValTest',
@@ -453,7 +453,7 @@ describe('SolidityCodeGenerator', () => {
       expect(outputOfGetChild).toBe(testOutputOfGetChild.toString())
       expect(outputOfDecide).toBe(testOutputOfDecide.toString())
     })
-    test('thereval2', () => {
+    test('thereval2', async () => {
       const input: IntermediateCompiledPredicate = {
         type: 'IntermediateCompiledPredicate',
         originalPredicateName: 'ThereValTest',

--- a/src/generator/solidity/SolidityCodeGenerator.ts
+++ b/src/generator/solidity/SolidityCodeGenerator.ts
@@ -30,7 +30,7 @@ export class SolidityCodeGenerator implements CodeGenerator {
       ovmPath: defaultOVMPath
     }
   ) {}
-  generate(compiledPredicates: CompiledPredicate[]) {
+  async generate(compiledPredicates: CompiledPredicate[]): Promise<string> {
     const template = ejs.compile(templateSource.toString(), { client: true })
     const output = template(
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,10 @@ import * as transpiler from './transpiler'
 
 export { parser, generator, transpiler }
 
-export function generateSolidityCode(
+export async function generateSolidityCode(
   source: string,
   options?: generator.SolidityCodeGeneratorOptions
-): string {
+): Promise<string> {
   const chamberParser = new parser.Parser()
   const compiledPredicates = transpiler.transpilePropertyDefsToCompiledPredicate(
     chamberParser.parse(source)
@@ -27,10 +27,10 @@ export function generateSolidityCode(
   return codeGenerator.generate(compiledPredicates)
 }
 
-export function generateEVMByteCode(
+export async function generateEVMByteCode(
   source: string,
   options?: generator.SolidityCodeGeneratorOptions
-): string {
+): Promise<string> {
   const chamberParser = new parser.Parser()
   const compiledPredicates = transpiler.transpilePropertyDefsToCompiledPredicate(
     chamberParser.parse(source)


### PR DESCRIPTION
When importing solc in jest or for client, an exception thrown.
https://github.com/ethereum/solc-js/issues/226

using dynamic import to avoid this problem.