### PR TITLE
Passing witness to children of And logical connective

### DIFF
--- a/packages/ethereum-generator/__test__/AndTestPredicateTestCase.ts
+++ b/packages/ethereum-generator/__test__/AndTestPredicateTestCase.ts
@@ -6,6 +6,7 @@ import {
   encodeProperty,
   encodeVariable,
   encodeInteger,
+  encodeChildWitnesses,
   TestCaseSet,
   TestContext
 } from '../src/helper'
@@ -69,7 +70,10 @@ export const createTestCaseOfAndLogicalConnective = (
         ) => {
           return {
             inputs: [encodeLabel('AndTestA'), transactionA, transactionB],
-            witnesses: ['0x', signature]
+            witnesses: [
+              encodeChildWitnesses([signature]),
+              encodeChildWitnesses([signature])
+            ]
           }
         }
       }

--- a/packages/ethereum-generator/src/helper/utils.ts
+++ b/packages/ethereum-generator/src/helper/utils.ts
@@ -69,3 +69,12 @@ export function encodeAddress(address: string) {
 export function randomAddress() {
   return hexlify(randomBytes(20))
 }
+
+/**
+ * encode witnesses for And logical connective's children
+ * Please see P_0 ∧ P_1 in https://github.com/cryptoeconomicslab/ovm-plasma-chamber-spec/blob/387767f5783639737f298cbae24e477f286d5b9e/core-spec/index.md#immediately-decide-table
+ * @param witnesses witnesses for And logical connective's children
+ */
+export function encodeChildWitnesses(witnesses: string[]) {
+  return abi.encode(['bytes[]'], [witnesses])
+}

--- a/packages/solidity-generator/src/decide.ejs
+++ b/packages/solidity-generator/src/decide.ejs
@@ -24,7 +24,7 @@
 <%      if(item.isCompiled) { -%>
             bytes[] memory childInputs<%= index %> = new bytes[](<%= item.inputs.length %>);
 <%- include('constructInputs', {property: item, valName: 'childInputs' + index, witnessName: '_witness[0]'}) -%>
-        require(decide(childInputs<%= index %>,  utils.subArray(_witness, 1, _witness.length)));
+        require(decide(childInputs<%= index %>,  abi.decode(_witness[<%= index %>], (bytes[]))));
 <%      } else { %>
 <%- include('decideProperty', {propIndex: index, property: item, valName: 'childInputs' + index}) -%>
 <%      } %>


### PR DESCRIPTION
Predicate requires witness to prove true.
So, the definition of decide method is `decide(bytes[] inputs, bytes[] witnesses)`.

Please read following table about required witness for each logical connective.
https://github.com/cryptoeconomicslab/ovm-plasma-chamber-spec/blob/master/core-spec/index.md#immediately-decide-table
we need array of witness because each predicate pass left of witnesses to their children.
However, And logical connective is problematic because we should pass multiple witness array for children of And logical connective.

| original      | witness | condition                     |
| ------------- | ------- | ----------------------------- |
| P_0 ∨ P_1     | w[0] is i       | `decide(P_i, w[1:])`                 |
| ¬¬P           | ∅       | `decide(P, w)`                   |
| ∃x ∈ X : p(x) | w[0] is t∈X     | `decide(p(x/t), w[1:])`              |
| P_0 ∧ P_1     | w are [w_0, ...w_i]       | `decide(P_0, w_0) and decide(P_1, w_1)` |

