### PR TITLE
Support predicates dynamic linking

### DIFF
--- a/packages/ethereum-generator/__test__/DynamicLinkTestCase.ts
+++ b/packages/ethereum-generator/__test__/DynamicLinkTestCase.ts
@@ -1,0 +1,72 @@
+import * as DynamicCallerTest from '../build/DynamicCallerTest.json'
+import * as DynamicCalledTest from '../build/DynamicCalledTest.json'
+import { ethers } from 'ethers'
+import {
+  encodeLabel,
+  encodeString,
+  encodeProperty,
+  encodeVariable,
+  encodeInteger,
+  encodeChildWitnesses,
+  TestCaseSet,
+  TestContext
+} from '../src/helper'
+
+const inputA = '0x000000000000000000000000000000000000000001'
+const inputB = '0x000000000000000000000000000000000000000002'
+const inputC = '0x000000000000000000000000000000000000000003'
+const signature = '0x000000000000000000000000000000000000000003'
+
+export const createTestCaseOfDynamicLink = (
+  wallet: ethers.Wallet
+): TestCaseSet => {
+  return {
+    name:
+      'def DynamicCallerTest(a, b, c) := DynamicCalledTest(a, b) and IsValidSignature(a, b, c)',
+    deploy: [
+      {
+        contract: DynamicCalledTest,
+        getExtraArgs: (context: TestContext) => []
+      },
+      {
+        contract: DynamicCallerTest,
+        getExtraArgs: (context: TestContext) => [
+          context.deployedContractAddresses[0]
+        ]
+      }
+    ],
+    validChallenges: [],
+    invalidChallenges: [],
+    decideTrueTestCases: [
+      {
+        name: 'DynamicCallerTest(a, b, c) should be true',
+        getTestData: (
+          andTestPredicate: ethers.Contract,
+          context: TestContext
+        ) => {
+          return {
+            inputs: [encodeLabel('DynamicCallerTestA'), inputA, inputB, inputC],
+            witnesses: [
+              encodeChildWitnesses([signature]),
+              encodeChildWitnesses([signature])
+            ]
+          }
+        }
+      }
+    ],
+    invalidDecideTestCases: [
+      {
+        name: 'should throw exception',
+        getTestData: (
+          andTestPredicate: ethers.Contract,
+          context: TestContext
+        ) => {
+          return {
+            inputs: [encodeLabel('DynamicCallerTestA'), inputA],
+            witnesses: [signature]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/packages/ethereum-generator/__test__/predicates.test.ts
+++ b/packages/ethereum-generator/__test__/predicates.test.ts
@@ -6,12 +6,14 @@ import * as ethers from 'ethers'
 import { TestCaseSet, setUpCompiledPredicateTest } from '../src/helper'
 import { createTestCaseOfAndLogicalConnective } from './AndTestPredicateTestCase'
 import { createTestCaseOfForAllSuchThatQuantifier } from './ForTestPredicateTestCase'
+import { createTestCaseOfDynamicLink } from './DynamicLinkTestCase'
 
 const createTestCases: (wallet: ethers.Wallet) => TestCaseSet[] = (
   wallet: ethers.Wallet
 ) => [
   createTestCaseOfAndLogicalConnective(wallet),
-  createTestCaseOfForAllSuchThatQuantifier(wallet)
+  createTestCaseOfForAllSuchThatQuantifier(wallet),
+  createTestCaseOfDynamicLink(wallet)
 ]
 
 setUpCompiledPredicateTest(

--- a/packages/ethereum-generator/contracts/predicate/DynamicCalledTest.ovm
+++ b/packages/ethereum-generator/contracts/predicate/DynamicCalledTest.ovm
@@ -1,0 +1,1 @@
+def DynamicCalledTest(a, b, c) := IsValidSignature(a, b, c) and IsValidSignature(a, b, c)

--- a/packages/ethereum-generator/contracts/predicate/DynamicCallerTest.ovm
+++ b/packages/ethereum-generator/contracts/predicate/DynamicCallerTest.ovm
@@ -1,0 +1,1 @@
+def DynamicCallerTest(a, b, c) := DynamicCalledTest(a, b, c) and DynamicCalledTest(a, b, c)

--- a/packages/ethereum-generator/src/template/CompiledPredicate.ts
+++ b/packages/ethereum-generator/src/template/CompiledPredicate.ts
@@ -10,6 +10,10 @@ interface CompiledPredicate {
         bytes[] calldata _challengeInputs,
         types.Property calldata _challenge
     ) external view returns (bool);
+    function getChild(
+        bytes[] calldata inputs,
+        bytes[] calldata challengeInput
+    ) external view returns (types.Property memory);
     function decide(bytes[] calldata _inputs, bytes[] calldata _witness)
         external
         view

--- a/packages/solidity-generator/src/SolidityCodeGenerator.test.ts
+++ b/packages/solidity-generator/src/SolidityCodeGenerator.test.ts
@@ -664,6 +664,7 @@ describe('SolidityCodeGenerator', () => {
       })
       expect(output).toBe(
         `        bytes[] memory inputs = new bytes[](0);
+        // This is for predicates dynamic linking
         require(
             CompiledPredicate(LibraryPredicate).decide(inputs, utils.subArray(_witness, 1, _witness.length)),
             "LibraryPredicate must be true"
@@ -883,6 +884,7 @@ describe('SolidityCodeGenerator', () => {
         uint256 challengeInput = abi.decode(challengeInputs[0], (uint256));
         bytes[] memory notInputs = new bytes[](1);
         if(challengeInput == 0) {
+            // This is for predicates dynamic linking
             bytes[] memory childInputs = new bytes[](0);
             return CompiledPredicate(CompiledPredicate).getChild(childInputs, utils.subArray(challengeInputs, 1, challengeInputs.length));
         }

--- a/packages/solidity-generator/src/SolidityCodeGenerator.test.ts
+++ b/packages/solidity-generator/src/SolidityCodeGenerator.test.ts
@@ -649,6 +649,29 @@ describe('SolidityCodeGenerator', () => {
       )
     })
 
+    test('CompiledPredicateCall', async () => {
+      const input: AtomicProposition = {
+        type: 'AtomicProposition',
+        predicate: {
+          type: 'CompiledPredicateCall',
+          source: 'LibraryPredicate'
+        },
+        inputs: []
+      }
+      const output = generator.includeCallback('decideProperty', {
+        property: input,
+        valName: 'inputs'
+      })
+      expect(output).toBe(
+        `        bytes[] memory inputs = new bytes[](0);
+        require(
+            CompiledPredicate(LibraryPredicate).decide(inputs, utils.subArray(_witness, 1, _witness.length)),
+            "LibraryPredicate must be true"
+        );
+`
+      )
+    })
+
     test('InputPredicateCall', async () => {
       const input: AtomicProposition = {
         type: 'AtomicProposition',
@@ -819,6 +842,64 @@ describe('SolidityCodeGenerator', () => {
       })
       expect(output).toBe(
         `        inputs = challengeInputs[0];
+`
+      )
+    })
+  })
+
+  describe('getChild', () => {
+    test('CompiledPredicateCall', async () => {
+      const input: IntermediateCompiledPredicate = {
+        type: 'IntermediateCompiledPredicate',
+        originalPredicateName: 'CompiledPredicateCallTest',
+        name: 'CompiledPredicateCallTestA',
+        connective: LogicalConnective.And,
+        inputDefs: ['CompiledPredicateCallTestA', 'a'],
+        inputs: [
+          {
+            type: 'AtomicProposition',
+            predicate: {
+              type: 'CompiledPredicateCall',
+              source: 'CompiledPredicate'
+            },
+            inputs: []
+          },
+          {
+            type: 'AtomicProposition',
+            predicate: { type: 'AtomicPredicateCall', source: 'Foo' },
+            inputs: []
+          }
+        ],
+        propertyInputs: []
+      }
+      const output = generator.includeCallback('getChild', {
+        property: input
+      })
+      expect(output).toBe(
+        `    /**
+     * Gets child of CompiledPredicateCallTestA(CompiledPredicateCallTestA,a).
+     */
+    function getChildCompiledPredicateCallTestA(bytes[] memory _inputs, bytes[] memory challengeInputs) private view returns (types.Property memory) {
+        uint256 challengeInput = abi.decode(challengeInputs[0], (uint256));
+        bytes[] memory notInputs = new bytes[](1);
+        if(challengeInput == 0) {
+            bytes[] memory childInputs = new bytes[](0);
+            return CompiledPredicate(CompiledPredicate).getChild(childInputs, utils.subArray(challengeInputs, 1, challengeInputs.length));
+        }
+        if(challengeInput == 1) {
+            bytes[] memory childInputsOf1 = new bytes[](0);
+
+            notInputs[0] = abi.encode(types.Property({
+                predicateAddress: Foo,
+                inputs: childInputsOf1
+            }));
+
+            return types.Property({
+                predicateAddress: notAddress,
+                inputs: notInputs
+            });
+        }
+    }
 `
       )
     })

--- a/packages/solidity-generator/src/decideProperty.ejs
+++ b/packages/solidity-generator/src/decideProperty.ejs
@@ -21,8 +21,15 @@
 <%  } else { -%>
         bytes[] memory <%= valName %> = new bytes[](<%= property.inputs.length %>);
 <%- include('constructInputs', {property: property, valName: valName, witnessName: '_witness[0]'}) -%>
+<%    if(property.predicate.type == 'CompiledPredicateCall') { -%>
+        require(
+            CompiledPredicate(<%= property.predicate.source %>).decide(<%= valName %>, utils.subArray(_witness, 1, _witness.length)),
+            "<%= property.predicate.source %> must be true"
+        );
+<%  } else { -%>
         require(
             AtomicPredicate(<%= property.predicate.source %>).decide(<%= valName %>),
             "<%= property.predicate.source %> must be true"
         );
+<%  } -%>
 <%  } -%>

--- a/packages/solidity-generator/src/decideProperty.ejs
+++ b/packages/solidity-generator/src/decideProperty.ejs
@@ -22,6 +22,7 @@
         bytes[] memory <%= valName %> = new bytes[](<%= property.inputs.length %>);
 <%- include('constructInputs', {property: property, valName: valName, witnessName: '_witness[0]'}) -%>
 <%    if(property.predicate.type == 'CompiledPredicateCall') { -%>
+        // This is for predicates dynamic linking
         require(
             CompiledPredicate(<%= property.predicate.source %>).decide(<%= valName %>, utils.subArray(_witness, 1, _witness.length)),
             "<%= property.predicate.source %> must be true"

--- a/packages/solidity-generator/src/getChild.ejs
+++ b/packages/solidity-generator/src/getChild.ejs
@@ -28,6 +28,10 @@
             bytes[] memory childInputs = new bytes[](<%= item.inputs.length %>);
 <%- indent(include('constructInputs', {property: item, valName: 'childInputs', witnessName: 'challengeInputs[0]'}), 4) -%>
             return getChild(childInputs, utils.subArray(challengeInputs, 1, challengeInputs.length));
+<%      } else if(item.predicate.type == 'CompiledPredicateCall') { -%>
+            bytes[] memory childInputs = new bytes[](<%= item.inputs.length %>);
+<%- indent(include('constructInputs', {property: item, valName: 'childInputs', witnessName: 'challengeInputs[0]'}), 4) -%>
+            return CompiledPredicate(<%= item.predicate.source %>).getChild(childInputs, utils.subArray(challengeInputs, 1, challengeInputs.length));
 <%      } else { -%>
 <%-  indent(include('constructProperty', {property: item, valName: 'notInputs[0]', propIndex: j, freeVariable: false}), 4) -%>
             return types.Property({

--- a/packages/solidity-generator/src/getChild.ejs
+++ b/packages/solidity-generator/src/getChild.ejs
@@ -29,6 +29,7 @@
 <%- indent(include('constructInputs', {property: item, valName: 'childInputs', witnessName: 'challengeInputs[0]'}), 4) -%>
             return getChild(childInputs, utils.subArray(challengeInputs, 1, challengeInputs.length));
 <%      } else if(item.predicate.type == 'CompiledPredicateCall') { -%>
+            // This is for predicates dynamic linking
             bytes[] memory childInputs = new bytes[](<%= item.inputs.length %>);
 <%- indent(include('constructInputs', {property: item, valName: 'childInputs', witnessName: 'challengeInputs[0]'}), 4) -%>
             return CompiledPredicate(<%= item.predicate.source %>).getChild(childInputs, utils.subArray(challengeInputs, 1, challengeInputs.length));

--- a/packages/transpiler/__test__/ContractCompiler.test.ts
+++ b/packages/transpiler/__test__/ContractCompiler.test.ts
@@ -723,5 +723,73 @@ describe('ContractCompiler', () => {
         ])
       })
     })
+    describe('library', () => {
+      test('decide other compiled predicates', () => {
+        const input: PropertyDef[] = [
+          {
+            annotations: [],
+            name: 'libraryTest',
+            inputDefs: ['a', 'b'],
+            body: {
+              type: 'PropertyNode',
+              predicate: 'And',
+              inputs: [
+                {
+                  type: 'PropertyNode',
+                  predicate: 'LibraryPredicate',
+                  inputs: ['a']
+                },
+                { type: 'PropertyNode', predicate: 'Foo', inputs: [] }
+              ]
+            }
+          }
+        ]
+        const output = createCompiledPredicates(input)
+        expect(output).toStrictEqual([
+          {
+            type: 'CompiledPredicate',
+            name: 'LibraryTest',
+            inputDefs: ['a', 'b'],
+            contracts: [
+              {
+                type: 'IntermediateCompiledPredicate',
+                originalPredicateName: 'LibraryTest',
+                name: 'LibraryTestA',
+                connective: LogicalConnective.And,
+                inputDefs: ['LibraryTestA', 'a', 'b'],
+                inputs: [
+                  {
+                    type: 'AtomicProposition',
+                    predicate: {
+                      type: 'CompiledPredicateCall',
+                      source: 'LibraryPredicate'
+                    },
+                    inputs: [
+                      { type: 'NormalInput', inputIndex: 1, children: [] }
+                    ]
+                  },
+                  {
+                    type: 'AtomicProposition',
+                    predicate: {
+                      type: 'AtomicPredicateCall',
+                      source: 'Foo'
+                    },
+                    inputs: []
+                  }
+                ],
+                propertyInputs: []
+              }
+            ],
+            constants: [
+              {
+                name: 'LibraryPredicate',
+                varType: 'address'
+              }
+            ],
+            entryPoint: 'LibraryTestA'
+          }
+        ])
+      })
+    })
   })
 })

--- a/packages/transpiler/src/CompiledPredicate.ts
+++ b/packages/transpiler/src/CompiledPredicate.ts
@@ -44,6 +44,7 @@ export type PredicateCall =
   | AtomicPredicateCall
   | InputPredicateCall
   | VariablePredicateCall
+  | CompiledPredicateCall
 
 /**
  * e.g. IsValidSignature()
@@ -66,6 +67,14 @@ export interface InputPredicateCall {
  */
 export interface VariablePredicateCall {
   type: 'VariablePredicateCall'
+}
+
+/**
+ * e.g. Confsig() user defined predicate
+ */
+export interface CompiledPredicateCall {
+  type: 'CompiledPredicateCall'
+  source: string
 }
 
 /**

--- a/packages/transpiler/src/CompiledPredicate.ts
+++ b/packages/transpiler/src/CompiledPredicate.ts
@@ -70,6 +70,7 @@ export interface VariablePredicateCall {
 }
 
 /**
+ * For predicates dynamic linking
  * e.g. Confsig() user defined predicate
  */
 export interface CompiledPredicateCall {

--- a/packages/transpiler/src/ContractCompiler.ts
+++ b/packages/transpiler/src/ContractCompiler.ts
@@ -176,9 +176,16 @@ function getPredicate(inputDefs: string[], name: string): PredicateCall {
       }
     }
   } else if (utils.isUpperCase(name[0])) {
-    return {
-      type: 'AtomicPredicateCall',
-      source: name
+    if (utils.isCompiledPredicate(name)) {
+      return {
+        type: 'CompiledPredicateCall',
+        source: name
+      }
+    } else {
+      return {
+        type: 'AtomicPredicateCall',
+        source: name
+      }
     }
   } else {
     return {
@@ -332,7 +339,7 @@ function getConstants(
   predicates.forEach(p => {
     p.inputs.forEach(i => {
       if (typeof i != 'string' && i.type == 'AtomicProposition') {
-        if (i.predicate.type == 'AtomicPredicateCall' && !i.isCompiled) {
+        if (i.predicate.type == 'CompiledPredicateCall' && !i.isCompiled) {
           const predicateName = i.predicate.source
           if (
             utils.isCompiledPredicate(predicateName) &&

--- a/packages/transpiler/src/ContractCompiler.ts
+++ b/packages/transpiler/src/ContractCompiler.ts
@@ -177,6 +177,7 @@ function getPredicate(inputDefs: string[], name: string): PredicateCall {
     }
   } else if (utils.isUpperCase(name[0])) {
     if (utils.isCompiledPredicate(name)) {
+      // This is for calling user defined predicate dybamically
       return {
         type: 'CompiledPredicateCall',
         source: name


### PR DESCRIPTION
## Overview

In this task, I'm making library system which is similar to dynamic link library. This compiler already supported static link with `@library` annotation.

We can use CompiledPredicate which is not atomic predicate. This is because we want to avoid big size predicate contract by defining multiple small predicates. Please check an example below. CompiledPredicate is the predicate I defined in other file.

```
MyPredicate(a, b) := CompiledPredicate(a) and IsValidSignature(b)
```

## Coge Generation

Generated code should call another CompiledPredicate dynamically
We should update 2 places in code generator.

getChild should call CompiledPredicate.getChild().

```
CompiledPredicate(CompiledPredicateAddress).getChild(inputs, witnesses)
```

decide should call CompiledPredicate.decide().

```
CompiledPredicate(CompiledPredicateAddress).decide(inputs, witnesses)
```
